### PR TITLE
date fields of GS1 barcodes should consider the timezone offset

### DIFF
--- a/spec/BarcodeParserSpec.js
+++ b/spec/BarcodeParserSpec.js
@@ -24,7 +24,7 @@ describe("A parsed GS1 barcode", () => {
         expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
             ai: "17",
             dataTitle: "USE BY OR EXPIRY",
-            data: new Date(2015, 0, 29, 0, 0, 0, 0)
+            data: new Date('2015-01-29')
         })]));
     });
 
@@ -93,7 +93,16 @@ describe("A parsed GS1 barcode", () => {
         expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
             ai: "17",
             dataTitle: "USE BY OR EXPIRY",
-            data: new Date(2019, 4, 31, 0, 0, 0, 0)
+            data: new Date('2019-05-31')
         })]));
+    });
+});
+
+describe("Date fields of a parsed GS1 barcode", () => {
+    it("should consider the timezone offset", () => {
+        const barcode = "15230300";
+        const result = parseBarcode(barcode);
+
+        expect(result.parsedCodeItems[0].data.toISOString()).toEqual('2023-03-31T00:00:00.000Z');
     });
 });

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -71,7 +71,7 @@ const parseBarcode = (function () {
                 break;
             case "D":
                 this.data = new Date();
-                this.data.setHours(0, 0, 0, 0);
+                this.data.setUTCHours(0, 0, 0, 0);
                 break;
             default:
                 this.data = "";
@@ -218,7 +218,7 @@ const parseBarcode = (function () {
                     monthAsNumber--;
                 }
 
-                elementToReturn.data.setFullYear(yearAsNumber, monthAsNumber, dayAsNumber);
+                elementToReturn.data.setUTCFullYear(yearAsNumber, monthAsNumber, dayAsNumber);
                 codestringToReturn = codestring.slice(offSet + 6, codestringLength);
                 elementToReturn.raw = codestring.slice(offSet, offSet+6);
             }


### PR DESCRIPTION
At the moment the method `parseBarcode` instantiates a date with the users current timezone. This could be problematic when storing the values of the date fields in a database.

For example the library parses the following GS1 barcode: `15240300`
A user who lives in a timezone with a negative offset of minus 1 hour would send the following ISO date to the server: `2024-03-30T23:00:00.000Z
The server interprets the date as an UTC date and would store the wrong value "2024-03-30" in the database.

Reading the date fields as UTC dates would fix this problem.
