### PR TITLE
fix switch braces

### DIFF
--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -1194,7 +1194,6 @@ const parseBarcode = (function () {
                             // Production method
                             parseVariableLength("7010", "PROD METHOD");
                             break;
-                        }
                         case "1":
                             // Test by date (and optional time)
                             parseVariableLength("7011", "TEST BY DATE");
@@ -1300,6 +1299,9 @@ const parseBarcode = (function () {
                             parseVariableLength("7242", "VCN");
                             break;
                         }
+                        break;
+                    }
+                    break;
                 default:
                     throw "21";
                 }


### PR DESCRIPTION
There was an error happening sometimes when scanning. The code ended up in the wrong switch default:

default:
    throw "19";

I fund the bug in the code with switch braces. I tested the fixed code and it seems to be working correctly now.