### PR TITLE
Reject truncated fixed length elements instead of returning a short or wrong value

### DIFF
--- a/spec/FixedLengthValidationSpec.js
+++ b/spec/FixedLengthValidationSpec.js
@@ -1,0 +1,125 @@
+/**
+ * Elements of fixed length are spliced out of the barcode by position. A
+ * barcode which was cut short used to yield a shorter slice instead of an
+ * error, so a partial scan came back looking like a valid code.
+ *
+ * These specs pin down that a fixed length element which isn't fully there
+ * is rejected, while everything else keeps parsing as before.
+ */
+const { parseBarcode } = require("../src/BarcodeParser");
+
+const fncChar = String.fromCharCode(29); // the ASCII "group separator"
+const truncationError = "truncated fixed length element";
+
+describe("A barcode with a truncated fixed length element", () => {
+    it("is rejected when the GTIN is too short", () => {
+        expect(() => parseBarcode("]C10104")).toThrow(truncationError);
+    });
+
+    it("is rejected when the GTIN has no data at all", () => {
+        expect(() => parseBarcode("]C101")).toThrow(truncationError);
+    });
+
+    it("is rejected when the truncated element ends a longer barcode", () => {
+        const barcode = `]C110ABC123${fncChar}0104012345`;
+
+        expect(() => parseBarcode(barcode)).toThrow(truncationError);
+    });
+
+    it("is rejected when a measure element is too short", () => {
+        expect(() => parseBarcode("]C131030052")).toThrow(truncationError);
+    });
+
+    it("is rejected without a symbology identifier as well", () => {
+        expect(() => parseBarcode("0104")).toThrow(truncationError);
+    });
+
+    it("is rejected when a date is a character short", () => {
+        expect(() => parseBarcode("]C11725063")).toThrow(truncationError);
+    });
+
+    it("is rejected when a date has no data at all", () => {
+        expect(() => parseBarcode("]C117")).toThrow(truncationError);
+    });
+});
+
+/**
+ * Counting the characters left in the barcode is not enough on its own. A
+ * separator inside the element's own window means the element ended early and
+ * the rest belongs to the element after it, so the data would otherwise be
+ * returned with a control character embedded in it.
+ */
+describe("A barcode where a separator cuts a fixed length element short", () => {
+    it("is rejected when a separator follows a short GTIN", () => {
+        expect(() => parseBarcode(`]C1010401234567890${fncChar}`)).toThrow(truncationError);
+    });
+
+    it("is rejected when a separator follows a short measure", () => {
+        expect(() => parseBarcode(`]C1310300052${fncChar}`)).toThrow(truncationError);
+    });
+
+    it("is rejected when a separator follows a short date", () => {
+        expect(() => parseBarcode(`]C11725063${fncChar}`)).toThrow(truncationError);
+    });
+
+    it("is rejected when the short element sits in the middle of the barcode", () => {
+        const barcode = `]C10104${fncChar}10ABCDEFGHI`;
+
+        expect(() => parseBarcode(barcode)).toThrow(truncationError);
+    });
+});
+
+describe("A barcode with a complete fixed length element", () => {
+    it("still parses the GTIN", () => {
+        const result = parseBarcode("]C10104012345678901");
+
+        expect(result.parsedCodeItems).toEqual([jasmine.objectContaining({
+            ai: "01",
+            dataTitle: "GTIN",
+            data: "04012345678901"
+        })]);
+    });
+
+    it("still parses a fixed length element followed by more data", () => {
+        const barcode = `]C10104012345678901${fncChar}10ABC123`;
+        const result = parseBarcode(barcode);
+
+        expect(result.parsedCodeItems).toEqual([
+            jasmine.objectContaining({ ai: "01", data: "04012345678901" }),
+            jasmine.objectContaining({ ai: "10", data: "ABC123" })
+        ]);
+    });
+
+    it("still parses a measure element", () => {
+        const result = parseBarcode("]C13103000525");
+
+        expect(result.parsedCodeItems).toEqual([jasmine.objectContaining({
+            ai: "3103",
+            dataTitle: "NET WEIGHT (kg)",
+            data: 0.525,
+            unit: "KGM"
+        })]);
+    });
+
+    it("still parses a date which is followed by a separator", () => {
+        const barcode = `]C117250630${fncChar}10ABC`;
+        const result = parseBarcode(barcode);
+
+        expect(result.parsedCodeItems).toEqual([
+            jasmine.objectContaining({ ai: "17", dataTitle: "USE BY OR EXPIRY" }),
+            jasmine.objectContaining({ ai: "10", data: "ABC" })
+        ]);
+    });
+});
+
+describe("A barcode with a short element of variable length", () => {
+    it("is accepted, as variable length elements have no minimum", () => {
+        const result = parseBarcode("]C110A");
+
+        expect(result.parsedCodeItems).toEqual([jasmine.objectContaining({
+            ai: "10",
+            dataTitle: "BATCH/LOT",
+            data: "A"
+        })]);
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -152,6 +152,29 @@ const parseBarcode = (function () {
                 return auxFloat;
             }
             /**
+             * Elements of fixed length are spliced out of the codestring by
+             * position, so a barcode which was cut short still yields a
+             * slice - just a shorter one than the AI allows.
+             *
+             * This function checks that the data is really there and throws
+             * if it isn't.
+             *
+             * @param {Number} offSet the number of characters taken by the AI
+             * @param {Number} length the number of characters the data needs
+             */
+            function checkFixedLength(offSet, length) {
+                if (codestringLength - offSet < length) {
+                    throw "37";
+                }
+                // Counting characters is not enough: a group separator inside
+                // the window means the element ended before the AI said it
+                // would, and the characters after it belong to the next
+                // element rather than to this one.
+                if (codestring.slice(offSet, offSet + length).indexOf(fncChar) !== -1) {
+                    throw "37";
+                }
+            }
+            /**
              * ======== END of auxiliary function for identifyAI =======
              */
 
@@ -175,8 +198,11 @@ const parseBarcode = (function () {
              */
             function parseDate(ai, title) {
                 elementToReturn = new ParsedElement(ai, title, "D");
-                var offSet = ai.length,
-                    dateYYMMDD = codestring.slice(offSet, offSet + 6),
+                var offSet = ai.length;
+
+                checkFixedLength(offSet, 6);
+
+                var dateYYMMDD = codestring.slice(offSet, offSet + 6),
                     yearAsNumber = 0,
                     monthAsNumber = 0,
                     dayAsNumber = 0;
@@ -247,6 +273,9 @@ const parseBarcode = (function () {
 
                 elementToReturn = new ParsedElement(ai, title, "S");
                 var offSet = ai.length;
+
+                checkFixedLength(offSet, length);
+
                 elementToReturn.data = codestring.slice(offSet, length + offSet);
                 codestringToReturn = codestring.slice(length + offSet, codestringLength);
                 elementToReturn.raw = codestring.slice(offSet, offSet + length);
@@ -292,8 +321,11 @@ const parseBarcode = (function () {
                 elementToReturn = new ParsedElement(ai_stem + fourthNumber, title, "N");
                 var offSet = ai_stem.length + 1,
                     numberOfDecimals = parseInt(fourthNumber, 10),
-                    numberPart = codestring.slice(offSet, offSet + 6);
+                    numberPart = "";
 
+                checkFixedLength(offSet, 6);
+
+                numberPart = codestring.slice(offSet, offSet + 6);
                 elementToReturn.data = parseFloatingPoint(numberPart, numberOfDecimals);
 
                 elementToReturn.unit = unit;
@@ -1702,6 +1734,8 @@ const parseBarcode = (function () {
                     throw "invalid day in date";
                 case "36":
                     throw "invalid number";
+                case "37":
+                    throw "truncated fixed length element";
                 default:
                     throw "unknown error";
                 }


### PR DESCRIPTION
Picks up an idea from @brhisats, whose fork has carried a length check on fixed-length fields since 2020.

## The problem

Fixed-length elements are spliced out of the barcode by position, so a barcode that was cut short still yields a slice — just a shorter one than the AI allows. A partial scan comes back looking like a valid code.

There are three fixed-length parsers and all three had it, in increasing order of how badly it fails:

| Parser | Truncated input | Result on `master` |
| --- | --- | --- |
| `parseFixedLength` | `]C10104` | GTIN of `"04"`, no error |
| `parseFixedLengthMeasure` | `]C131030052` | net weight **0.052 kg** instead of 0.525 kg |
| `parseDate` | `]C11725063` | expiry **2025-06-03** instead of 2025-06-30 |

The measure and date cases are the dangerous ones: the short slice runs through `parseFloatingPoint` or `parseInt` and produces a plausible value rather than failing. A wrong expiry date reads exactly like a real one.

## The fix

All three now check the data is really there and throw `"37"`, mapped to `truncated fixed length element`.

Counting the characters left in the barcode is not enough on its own. A group separator inside the element's own window means the element ended early and the rest belongs to the next element, so that is rejected too. Without that half, a single trailing separator defeated the whole guard — `]C1` + `01` + 13 digits + `<GS>` passed a character count while being exactly the truncation the check exists to catch — and an element cut short mid-barcode came back with a control character embedded in its data.

Variable-length elements are untouched. They have no minimum, so a short one is not evidence of truncation.

## Behaviour change

Input that used to return quietly wrong data now throws. Two things worth knowing before this ships:

- Because the parse loop unwinds on a throw, a barcode whose **last** element is truncated now loses the elements that parsed correctly before it.
- Callers that relied on lenient parsing will start seeing exceptions. For a caller that already wraps `parseBarcode` in a try/catch and falls back, this is an improvement — a hard failure instead of a silently wrong expiry date.

## Tests

16 new specs in `spec/FixedLengthValidationSpec.js`, covering each of the three parsers, the separator-inside-the-window case, truncation at the end and in the middle of a barcode, and the variable-length elements that must keep parsing. 219 specs total, 0 failures.

The 193-entry AI table is unchanged and still passes, so no supported identifier regressed.
