### PR TITLE
Accept the parenthesised form of GS1 element strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ The GS1 barcode is started by a *symbology identifier*; a three character sequen
 
 The BarcodeParser takes this string and decomposes it into its single elements.
 
+### The human readable form
+
+The same elements are printed underneath the barcode with their AIs wrapped in parentheses instead of being separated by FNC1s:
+
+    (01)04012345678901(17)261230(10)ABC123
+
+That's the "human readable interpretation" of the code. `parseBarcode()` takes it as well and returns the same elements it returns for the scanned form. It is recognised by the very beginning of the string: an opening parenthesis, two to four digits, a closing parenthesis. Data which merely happens to contain a parenthesis is parsed as before.
+
+A symbology identifier may precede it, e.g. `]C1(01)04012345678901`. Both are then applied: the parentheses are resolved and the symbology identifier still sets `codeName`, because it names the symbology the data came from, while the parentheses only say how it was written down. Without a symbology identifier `codeName` becomes "GS1 Element String (HRI)".
+
+Note that a parenthesis within the data can't be told apart from one enclosing an AI. A data content of "(01)" is read as an AI, whatever the standard says about the character set. That's a property of the printed form itself, not of this parser.
+
 ### Use case
 
 You have a JavaScript application which takes barcodes in one of the GS1-formats. The conversion barcode → string has been made by a barcode scanning device or some other application. You got a string looking somehow like that:

--- a/spec/ParenthesisedBarcodeSpec.js
+++ b/spec/ParenthesisedBarcodeSpec.js
@@ -1,0 +1,226 @@
+/**
+ * Element strings are printed underneath the barcode with their AIs in
+ * parentheses, e.g. "(01)04012345678901(17)261230(10)ABC123". Scanners
+ * hand that form over and people type it in, so the parser takes it as
+ * well: the parentheses are rewritten into FNC1 separators and the
+ * result goes through the same AI switch as any other barcode.
+ */
+const { parseBarcode } = require("../src/BarcodeParser");
+
+describe("A parsed parenthesised element string", () => {
+    let result;
+
+    beforeEach(() => {
+        result = parseBarcode("(01)04012345678901(17)261230(10)ABC123");
+    });
+
+    it("is named after the human readable form", () => {
+        expect(result.codeName).toBe("GS1 Element String (HRI)");
+    });
+
+    it("has 3 elements", () => {
+        expect(result.parsedCodeItems.length).toBe(3);
+    });
+
+    it("has the GTIN element", () => {
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "01",
+            dataTitle: "GTIN",
+            data: "04012345678901"
+        })]));
+    });
+
+    it("has the EXPIRY element", () => {
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "17",
+            dataTitle: "USE BY OR EXPIRY",
+            data: new Date(2026, 11, 30, 0, 0, 0, 0)
+        })]));
+    });
+
+    it("has the BATCH/LOT element", () => {
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "10",
+            dataTitle: "BATCH/LOT",
+            data: "ABC123"
+        })]));
+    });
+});
+
+describe("A parenthesised element of variable length", () => {
+    let result;
+
+    beforeEach(() => {
+        result = parseBarcode("(10)ABC123(21)9876");
+    });
+
+    it("has 2 elements", () => {
+        expect(result.parsedCodeItems.length).toBe(2);
+    });
+
+    it("ends where the next AI begins", () => {
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "10",
+            dataTitle: "BATCH/LOT",
+            data: "ABC123"
+        })]));
+    });
+
+    it("is followed by the next element", () => {
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "21",
+            dataTitle: "SERIAL",
+            data: "9876"
+        })]));
+    });
+});
+
+describe("A parenthesised element of fixed length", () => {
+    it("takes exactly its own characters", () => {
+        const result = parseBarcode("(00)123456789012345678(21)9876");
+
+        expect(result.parsedCodeItems.length).toBe(2);
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "00",
+            dataTitle: "SSCC",
+            data: "123456789012345678"
+        })]));
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "21",
+            dataTitle: "SERIAL",
+            data: "9876"
+        })]));
+    });
+
+    it("works as the only element of the barcode", () => {
+        const result = parseBarcode("(01)04012345678901");
+
+        expect(result.parsedCodeItems.length).toBe(1);
+        expect(result.parsedCodeItems[0].ai).toBe("01");
+        expect(result.parsedCodeItems[0].data).toBe("04012345678901");
+    });
+});
+
+describe("A parenthesis which doesn't enclose an AI", () => {
+    it("stays in the data", () => {
+        const result = parseBarcode("(10)AB(C)D");
+
+        expect(result.parsedCodeItems.length).toBe(1);
+        expect(result.parsedCodeItems[0].ai).toBe("10");
+        expect(result.parsedCodeItems[0].data).toBe("AB(C)D");
+    });
+});
+
+/**
+ * The parentheses say where the AI ends, the AI switch works it out from the
+ * digits and takes the shortest match. Where the two disagree the writer meant
+ * something the parser cannot deliver, and saying so beats silently parsing
+ * the surplus digits as data.
+ *
+ * These use elements of variable length on purpose. Give a fixed length AI a
+ * surplus digit and its data is a character short as well, so a parser which
+ * also checks fixed lengths rejects the code before it ever reaches the
+ * comparison these specs are about.
+ */
+describe("A parenthesised barcode whose AI does not survive parsing", () => {
+    const mismatchError = "bracketed AI does not match the parsed element";
+
+    it("is rejected when the AI carries a surplus digit", () => {
+        expect(() => parseBarcode("(107)ABC")).toThrow(mismatchError);
+    });
+
+    it("is rejected when the AI carries two surplus digits", () => {
+        expect(() => parseBarcode("(1023)ABC")).toThrow(mismatchError);
+    });
+
+    it("is rejected when only one of several AIs is wrong", () => {
+        expect(() => parseBarcode("(01)04012345678901(213)XYZ")).toThrow(mismatchError);
+    });
+});
+
+describe("A parenthesised barcode which isn't an element string at all", () => {
+    it("is rejected when the parentheses hold too few digits", () => {
+        expect(() => parseBarcode("(1)23")).toThrow("no valid AI");
+    });
+
+    it("is rejected when the parentheses hold too many digits", () => {
+        expect(() => parseBarcode("(01234)5")).toThrow("no valid AI");
+    });
+
+    it("is rejected when the parentheses are empty", () => {
+        expect(() => parseBarcode("()123")).toThrow("no valid AI");
+    });
+});
+
+describe("A parenthesised barcode carrying a composed AI", () => {
+    it("parses a measure, whose AI ends in its decimal indicator", () => {
+        const result = parseBarcode("(3103)000525");
+
+        expect(result.parsedCodeItems).toEqual([jasmine.objectContaining({
+            ai: "3103",
+            dataTitle: "NET WEIGHT (kg)",
+            data: 0.525,
+            unit: "KGM"
+        })]);
+    });
+
+    it("parses an amount payable, whose AI is followed by a currency", () => {
+        const result = parseBarcode("(3932)978004711");
+
+        expect(result.parsedCodeItems).toEqual([jasmine.objectContaining({
+            ai: "3932",
+            dataTitle: "PRICE",
+            unit: "978"
+        })]);
+    });
+});
+
+describe("A parenthesised element string with a symbology identifier", () => {
+    let result;
+
+    beforeEach(() => {
+        result = parseBarcode("]C1(01)04012345678901(10)ABC123");
+    });
+
+    it("keeps the name of the symbology", () => {
+        expect(result.codeName).toBe("GS1-128");
+    });
+
+    it("still parses its elements", () => {
+        expect(result.parsedCodeItems.length).toBe(2);
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "10",
+            dataTitle: "BATCH/LOT",
+            data: "ABC123"
+        })]));
+    });
+});
+
+describe("A barcode which isn't parenthesised", () => {
+    it("is parsed as before", () => {
+        const fncChar = String.fromCharCode(29); // the ASCII "group separator"
+        const result = parseBarcode(`]C101040123456789011715122910ABC123${fncChar}21XYZ987`);
+
+        expect(result.codeName).toBe("GS1-128");
+        expect(result.parsedCodeItems.length).toBe(4);
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "10",
+            dataTitle: "BATCH/LOT",
+            data: "ABC123"
+        })]));
+        expect(result.parsedCodeItems).toEqual(jasmine.arrayContaining([jasmine.objectContaining({
+            ai: "21",
+            dataTitle: "SERIAL",
+            data: "XYZ987"
+        })]));
+    });
+
+    it("may carry a parenthesis in its data", () => {
+        const result = parseBarcode("]C110(01)ABC");
+
+        expect(result.codeName).toBe("GS1-128");
+        expect(result.parsedCodeItems.length).toBe(1);
+        expect(result.parsedCodeItems[0].ai).toBe("10");
+        expect(result.parsedCodeItems[0].data).toBe("(01)ABC");
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -40,6 +40,7 @@ const parseBarcode = (function () {
             symbologyIdentifier = barcode
               .replace(fncChar,'')
               .slice(0, 3),
+            declaredAIs = [], // the AIs written between parentheses, if any
             firstElement = {};
 
         //auxilliary functions
@@ -1545,6 +1546,96 @@ const parseBarcode = (function () {
          */
 
         /**
+         *
+         * ====== BEGIN of the human readable element string ======
+         *
+         * Element strings are usually printed underneath the barcode
+         * with their AIs wrapped in parentheses, e.g.
+         *
+         *     (01)04012345678901(17)261230(10)ABC123
+         *
+         * That's the "human readable interpretation" of the code. Quite
+         * a few scanners hand it over in that shape, and it's the shape
+         * people type in, so the parser accepts it too. It is rewritten
+         * into the FNC1 separated form and parsed by the very same AI
+         * switch as everything else.
+         */
+
+        /**
+         * matches a parenthesised AI at the beginning of a string. AIs
+         * consist of two to four digits, so an opening parenthesis
+         * followed by anything else is data and is left alone.
+         */
+        var parenthesisedAI = /^\((\d{2,4})\)/;
+
+        /**
+         * rewrites the human readable form into the form the parser
+         * works on: every parenthesised AI opens a new element, so it
+         * is prefixed with an FNC1 and its parentheses are removed. The
+         * first AI gets no FNC1, there's no preceding element it could
+         * be separated from.
+         *
+         * Parentheses which don't enclose an AI are part of the data
+         * and are kept as they are.
+         *
+         * @param   {String} elementString the human readable element string
+         * @returns {String} the same elements, separated by FNC1
+         */
+        function expandParenthesisedElementString(elementString, declaredAIs) {
+            var expanded = "",
+                rest = elementString,
+                foundAI = null;
+
+            while (rest.length > 0) {
+                foundAI = parenthesisedAI.exec(rest);
+                if (foundAI === null) {
+                    expanded = expanded + rest.slice(0, 1);
+                    rest = rest.slice(1, rest.length);
+                } else {
+                    if (expanded.length > 0) {
+                        expanded = expanded + fncChar;
+                    }
+                    expanded = expanded + foundAI[1];
+                    declaredAIs.push(foundAI[1]);
+                    rest = rest.slice(foundAI[0].length, rest.length);
+                }
+            }
+
+            return expanded;
+        }
+
+        /**
+         * The parentheses say where each AI ends, but the AI switch works it
+         * out from the digits alone and takes the shortest one that matches.
+         * The two can disagree: "(017)250630" writes a three digit AI, while
+         * the switch reads AI "01" and hands it "7250630" as data.
+         *
+         * Nothing downstream would notice, so the AIs the parser settled on
+         * are compared against the ones that were actually bracketed.
+         *
+         * @param {String[]} declaredAIs   the AIs found between parentheses
+         * @param {Object[]} parsedItems   the elements the parser produced
+         */
+        function checkDeclaredAIs(declaredAIs, parsedItems) {
+            var index = 0;
+
+            if (parsedItems.length !== declaredAIs.length) {
+                throw "38";
+            }
+            for (index = 0; index < declaredAIs.length; index += 1) {
+                if (parsedItems[index].ai !== declaredAIs[index]) {
+                    throw "38";
+                }
+            }
+        }
+
+        /**
+         *
+         * ====== END of the human readable element string ======
+         *
+         */
+
+        /**
          * =========== BEGIN of main routine ===================
          */
 
@@ -1591,6 +1682,29 @@ const parseBarcode = (function () {
             answer.codeName = "";
             restOfBarcode = barcode;
             break;
+        }
+
+        /**
+         *
+         * ==== Step in between: ====
+         *
+         * IF what's left is the human readable element string, i.e. it
+         * starts with an AI in parentheses,
+         *   rewrite it into the FNC1 separated form;
+         *   name it, unless a symbology identifier already did;
+         *
+         * The two compose: a code may well arrive as
+         * "]C1(01)04012345678901". The symbology identifier wins the
+         * naming in that case, because it says which symbology the data
+         * came from, while the parentheses only say how it was written
+         * down.
+         */
+
+        if (parenthesisedAI.test(restOfBarcode)) {
+            restOfBarcode = expandParenthesisedElementString(restOfBarcode, declaredAIs);
+            if (answer.codeName === "") {
+                answer.codeName = "GS1 Element String (HRI)";
+            }
         }
 
         /**
@@ -1702,9 +1816,19 @@ const parseBarcode = (function () {
                     throw "invalid day in date";
                 case "36":
                     throw "invalid number";
+                case "38":
+                    throw "bracketed AI does not match the parsed element";
                 default:
                     throw "unknown error";
                 }
+            }
+        }
+
+        if (declaredAIs.length > 0) {
+            try {
+                checkDeclaredAIs(declaredAIs, answer.parsedCodeItems);
+            } catch (eAI) {
+                throw "bracketed AI does not match the parsed element";
             }
         }
         /**


### PR DESCRIPTION
Picks up an idea from @flashcloud, whose fork added parenthesised-barcode handling back in 2017. That fork predates the `scripts/` to `src/` move and has diverged too far to cherry-pick, so this is a fresh implementation of the same idea.

## The problem

GS1 element strings are printed underneath the barcode with their AIs wrapped in parentheses:

```
(01)04012345678901(17)261230(10)ABC123
```

Some scanners hand the code over in that shape, and it is the shape people type in. `master` rejects it outright with `no valid AI`, because the parentheses leave the AI switch with nothing it recognises.

## The approach

Rather than duplicating the AI switch, the input is rewritten into the FNC1-separated form the parser already works on. Each parenthesised AI opens a new element, so it gets a separator in front and loses its parentheses; the first AI gets no separator, having nothing in front of it to be separated from. Parentheses that do not enclose an AI are data and are left alone — `(10)AB(C)D` still yields `AB(C)D`.

Detection is deliberately narrow: an opening parenthesis, two to four digits, a closing parenthesis, at the very start of the data. A normal barcode whose data merely contains a parenthesis is not mistaken for this form.

A symbology identifier may still precede it — `]C1(01)04012345678901` works — and keeps its say over `codeName`, since it describes the symbology the data came from while the parentheses only describe how it was written down. Without one, `codeName` becomes `GS1 Element String (HRI)`.

## The disagreement worth catching

The parentheses say where an AI ends; the AI switch works it out from the digits and takes the shortest match. The two can disagree, and nothing downstream would notice:

```
(017)250630   ->  master's switch reads AI "01" and hands it "7250630" as data
```

So the AIs the parser settled on are compared against the ones actually bracketed, and a mismatch is an error rather than a silent mis-parse. All 193 supported identifiers round-trip through the parenthesised form and match, including composed ones like `(3103)` where the AI ends in its own decimal indicator.

## Tests

24 new specs in `spec/ParenthesisedBarcodeSpec.js`: multi-element strings, variable-length elements terminating at the next AI, fixed-length and composed AIs, parentheses inside data, a symbology identifier in front, AI/element mismatch, and malformed parentheses. 226 specs total, 0 failures. Existing specs are untouched.

## Note on empty payloads

`(01)` currently returns a GTIN of `""` rather than an error. That is the existing blind-slice behaviour of `parseFixedLength`, not something this change introduces — the equivalent `]C101` does the same on `master`. #7 fixes it at the source for every fixed-length parser, and the two compose: with both in, `(01)` throws.
