### PR TITLE
Take coverage to 100%, fixing a real gap on the way

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -10,8 +10,8 @@
     ],
     "report-dir": "coverage",
     "check-coverage": true,
-    "statements": 99,
-    "branches": 97,
+    "statements": 100,
+    "branches": 100,
     "functions": 100,
-    "lines": 99
+    "lines": 100
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Releases before 1.0.3 predate this file and are not reconstructed here.
   went from 94% of statements and 77% of branches to 99% and 97%. ([#11])
 - Identifiers `7030`-`7039`, `7230`-`7239` and `8026`, which the parser supported but which
   were missing from the table meant to hold all of them. ([#11])
+- Specs taking coverage to 100% of statements, branches, functions and lines, with the
+  thresholds set there. The far half of the sliding year window is reached by moving the
+  clock, being otherwise unreachable until 2050. ([#13])
+
+### Fixed
+
+- A date or a measure written in something other than digits is refused instead of coming
+  back as a successful parse holding an `Invalid Date` or a null weight. Both were read with
+  `parseInt` and `parseFloat`, wrapped in a `try` which could never fire because neither
+  throws on rubbish — they return `NaN`. ([#13])
 
 ### Changed
 
@@ -123,3 +133,4 @@ rest of the tags exist.
 [#8]: https://github.com/MaximBelov/BarcodeParser/pull/8
 [#10]: https://github.com/MaximBelov/BarcodeParser/pull/10
 [#11]: https://github.com/MaximBelov/BarcodeParser/pull/11
+[#13]: https://github.com/MaximBelov/BarcodeParser/pull/13

--- a/README.md
+++ b/README.md
@@ -240,19 +240,14 @@ exercises fails rather than passing quietly.
 there for editors and other tools. Neither is checked in. Every CI run prints the table
 in its job summary and attaches the HTML report as an artifact.
 
-What is left uncovered is code which cannot be reached, rather than code nobody got round
-to:
+The suite covers 100% of statements, branches, functions and lines, and the thresholds are
+set there, so anything less fails the build.
 
-- the `catch` arms around `parseInt` and `parseFloat`, neither of which throws, and the
-  messages they map to;
-- the `default` arm of the element type switch, since every caller passes a known type;
-- the `default` arm of the message switch, since every code in use has an arm of its own;
-- the half of the sliding year window which reads a year as belonging to the century ahead.
-  It needs a two digit year at least fifty behind the current one, which cannot be written
-  in two digits before 2050.
-
-Deleting unreachable code would be a change to the parser rather than to its specs, so it
-is left alone and written down here instead.
+Two guards are held out of that figure with `c8 ignore`, each with a comment saying why:
+the `default` arm of the element type switch, and the `default` arm of the message switch.
+Neither can be reached — every caller passes a known type, and every code the parser throws
+has an arm of its own — and both are worth keeping as guards. They are excluded rather than
+deleted, which would have been flattering the number at the cost of the code.
 
 CI runs the same commands on every push and pull request. A push to `master` whose
 `package.json` version is not yet on the registry is published to npm through

--- a/spec/SlidingYearWindowSpec.js
+++ b/spec/SlidingYearWindowSpec.js
@@ -1,17 +1,16 @@
 /**
  * Dates carry a two digit year, so the century has to be guessed. Section 7.1.2
  * of the GS1 General Specifications puts a sliding window around the current
- * year: a year more than fifty ahead is read as belonging to the century before,
- * rather than the fixed "51 to 99 is the twentieth century" rule upstream used.
+ * year: a year more than fifty ahead belongs to the century before, and one more
+ * than forty nine behind to the century after, rather than the fixed "51 to 99 is
+ * the twentieth century" rule upstream used.
  *
- * The window moves with the clock, so these work out the year to use rather than
- * hard coding one, which would start failing on its own some year from now.
+ * The window moves with the clock, so the year is worked out here rather than
+ * hard coded. The far edges are reached by moving the clock instead, which is the
+ * only way to see the century-ahead half at all: it needs a two digit year fifty
+ * behind the current one, and that cannot be written in two digits until 2050.
  */
 const { parseBarcode } = require("../src/BarcodeParser");
-
-const currentYear = new Date().getUTCFullYear();
-const currentTwoDigits = currentYear % 100;
-const currentCentury = currentYear - currentTwoDigits;
 
 function expiryFor(twoDigitYear) {
     const asText = String(twoDigitYear).padStart(2, "0");
@@ -19,12 +18,20 @@ function expiryFor(twoDigitYear) {
     return parseBarcode(`]C117${asText}0601`).parsedCodeItems[0].data;
 }
 
-describe("The sliding window around the current year", () => {
+describe("The sliding window, as the clock stands today", () => {
+    const currentYear = new Date().getUTCFullYear();
+    const currentTwoDigits = currentYear % 100;
+    const currentCentury = currentYear - currentTwoDigits;
+
+    it("reads the current year as the current century", () => {
+        expect(expiryFor(currentTwoDigits).getFullYear()).toBe(currentYear);
+    });
+
     it("reads a year just inside the window as this century", () => {
         const inside = currentTwoDigits + 50;
 
         if (inside > 99) {
-            pending("a year fifty ahead is past 99 and cannot be written in two digits");
+            pending("a year fifty ahead cannot be written in two digits from here");
             return;
         }
 
@@ -35,26 +42,49 @@ describe("The sliding window around the current year", () => {
         const outside = currentTwoDigits + 51;
 
         if (outside > 99) {
-            pending("a year fifty one ahead is past 99 and cannot be written in two digits");
+            pending("a year fifty one ahead cannot be written in two digits from here");
             return;
         }
 
         expect(expiryFor(outside).getFullYear()).toBe(currentCentury + outside - 100);
     });
+});
 
-    it("reads the current year as the current century", () => {
-        expect(expiryFor(currentTwoDigits).getFullYear()).toBe(currentYear);
+describe("The sliding window, with the clock moved", () => {
+    beforeEach(() => {
+        jasmine.clock().install();
     });
 
-    it("moves the whole window with the clock rather than cutting at 50", () => {
-        const inside = currentTwoDigits + 50;
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
 
-        if (inside > 99 || inside <= 50) {
-            pending("the window does not reach past 50 from this year");
-            return;
-        }
+    it("puts a year fifty behind into the century ahead", () => {
+        jasmine.clock().mockDate(new Date(2060, 5, 1));
 
-        // Upstream's fixed rule would have made anything above 50 a 19xx year.
-        expect(expiryFor(inside).getFullYear()).toBeGreaterThan(currentYear);
+        // 2060, so "10" is fifty behind and reads as 2110 rather than 2010.
+        expect(expiryFor(10).getFullYear()).toBe(2110);
+    });
+
+    it("keeps a year forty nine behind in the current century", () => {
+        jasmine.clock().mockDate(new Date(2060, 5, 1));
+
+        expect(expiryFor(11).getFullYear()).toBe(2011);
+    });
+
+    it("still puts a year fifty one ahead into the century before", () => {
+        // Both edges cannot be written in two digits from the same year, so this
+        // one is taken from 2005, where fifty one ahead is 56.
+        jasmine.clock().mockDate(new Date(2005, 5, 1));
+
+        expect(expiryFor(56).getFullYear()).toBe(1956);
+    });
+
+    it("moves the whole window rather than cutting at a fixed year", () => {
+        jasmine.clock().mockDate(new Date(2005, 5, 1));
+
+        // Upstream's fixed rule read anything above 50 as 19xx. In 2005 the
+        // window reaches to 2055, so 55 is ahead of us, not half a century back.
+        expect(expiryFor(55).getFullYear()).toBe(2055);
     });
 });

--- a/spec/UnreadableNumbersSpec.js
+++ b/spec/UnreadableNumbersSpec.js
@@ -1,0 +1,60 @@
+/**
+ * Dates and measures are read with parseInt and parseFloat, neither of which
+ * throws on rubbish: they return NaN. The parser wrapped both in a try which
+ * could therefore never fire, and a barcode carrying letters where it should
+ * carry digits came back as a successful parse holding an Invalid Date or a
+ * null weight, leaving every caller to notice for itself.
+ */
+const { parseBarcode } = require("../src/BarcodeParser");
+
+describe("A date which is not made of digits", () => {
+    it("is refused rather than returned as an Invalid Date", () => {
+        expect(() => parseBarcode("]C117ABCDEF")).toThrow("invalid year in date");
+    });
+
+    it("is refused when only the month is unreadable", () => {
+        expect(() => parseBarcode("]C11725AB30")).toThrow("invalid month in date");
+    });
+
+    it("is refused when only the day is unreadable", () => {
+        expect(() => parseBarcode("]C1172506AB")).toThrow("invalid day in date");
+    });
+
+    it("is refused on a production date as well as an expiry", () => {
+        expect(() => parseBarcode("]C111XXXXXX")).toThrow("invalid year in date");
+    });
+});
+
+describe("A measure which is not made of digits", () => {
+    it("is refused rather than returned as null", () => {
+        expect(() => parseBarcode("]C13103ABCDEF")).toThrow("invalid number");
+    });
+
+    it("is refused for an amount payable too", () => {
+        expect(() => parseBarcode("]C13922ABCDEF")).toThrow("invalid number");
+    });
+});
+
+describe("A date which is made of digits", () => {
+    it("still parses", () => {
+        const result = parseBarcode("]C117250630");
+
+        expect(result.parsedCodeItems[0].data.getFullYear()).toBe(2025);
+        expect(result.parsedCodeItems[0].data.getDate()).toBe(30);
+    });
+
+    it("still turns a day of 00 into the last day of the month", () => {
+        const result = parseBarcode("]C117250600");
+
+        expect(result.parsedCodeItems[0].data.getMonth()).toBe(5);
+        expect(result.parsedCodeItems[0].data.getDate()).toBe(30);
+    });
+});
+
+describe("A measure which is made of digits", () => {
+    it("still parses, decimals and all", () => {
+        const result = parseBarcode("]C13103000525");
+
+        expect(result.parsedCodeItems[0].data).toBe(0.525);
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -73,9 +73,14 @@ const parseBarcode = (function () {
                 this.data = new Date();
                 this.data.setHours(0, 0, 0, 0);
                 break;
+            /* c8 ignore start -- every construction in this file passes S, N or
+               D, so this arm cannot be reached. It stays as the guard it is,
+               and is kept out of the coverage figure rather than being dropped
+               to flatter it. */
             default:
                 this.data = "";
                 break;
+            /* c8 ignore stop */
             }
             this.unit = ""; // some elements are accompaigned by an unit of
             // measurement or currency
@@ -144,9 +149,13 @@ const parseBarcode = (function () {
                 auxString = stringToParse.slice(0, offset) +
                             '.' +
                             stringToParse.slice(offset, stringToParse.length);
-                try {
-                    auxFloat = parseFloat(auxString);
-                } catch (e36) {
+
+                // parseFloat does not throw on rubbish, it returns NaN, so the
+                // number has to be looked at rather than merely parsed. Without
+                // this a measure written in letters came back as a successful
+                // parse carrying null.
+                auxFloat = parseFloat(auxString);
+                if (isNaN(auxFloat)) {
                     throw "36";
                 }
 
@@ -212,22 +221,24 @@ const parseBarcode = (function () {
                     currentCentury = currentCCYY - currentYear,
                     yearGap = 0;
 
-                try {
-                    yearAsNumber = parseInt(dateYYMMDD.slice(0, 2), 10);
-                    yearGap = yearAsNumber - currentYear;
-                } catch (e33) {
+                // parseInt does not throw on rubbish, it returns NaN, so each
+                // part has to be looked at rather than merely parsed. Without
+                // this a date written in letters came back as a successful
+                // parse carrying an Invalid Date, which every caller then had
+                // to notice for itself.
+                yearAsNumber = parseInt(dateYYMMDD.slice(0, 2), 10);
+                if (isNaN(yearAsNumber)) {
                     throw "33";
                 }
+                yearGap = yearAsNumber - currentYear;
 
-                try {
-                    monthAsNumber = parseInt(dateYYMMDD.slice(2, 4), 10);
-                } catch (e34) {
+                monthAsNumber = parseInt(dateYYMMDD.slice(2, 4), 10);
+                if (isNaN(monthAsNumber)) {
                     throw "34";
                 }
 
-                try {
-                    dayAsNumber = parseInt(dateYYMMDD.slice(4, 6), 10);
-                } catch (e35) {
+                dayAsNumber = parseInt(dateYYMMDD.slice(4, 6), 10);
+                if (isNaN(dayAsNumber)) {
                     throw "35";
                 }
                 // Year determination
@@ -1850,8 +1861,13 @@ const parseBarcode = (function () {
                     throw "invalid number";
                 case "37":
                     throw "truncated fixed length element";
+                /* c8 ignore start -- every code the parser throws has an arm
+                   above, so this one cannot be reached. It stays as the guard
+                   it is, and is kept out of the coverage figure rather than
+                   being dropped to flatter it. */
                 default:
                     throw "unknown error";
+                /* c8 ignore stop */
                 }
             }
         }


### PR DESCRIPTION
Yes — 100% of statements, branches, functions and lines. Getting there turned up a real bug rather than just moving a number.

## The bug

Dates and measures are read with `parseInt` and `parseFloat`, each wrapped in a `try`. Neither function throws on rubbish; they return `NaN`. So the `catch` blocks could never fire, and a barcode carrying letters where it should carry digits came back as a **successful parse**:

```
]C117ABCDEF    ->  { ai: "17", data: Invalid Date }
]C13103ABCDEF  ->  { ai: "3103", data: null }
```

`Invalid Date` is still `instanceof Date`, so a caller checking the type sees nothing wrong and only finds out downstream.

The parse now looks at the number rather than merely reading it — which is what those `catch` blocks were written to do — and refuses with `invalid year in date`, `invalid month in date`, `invalid day in date` or `invalid number`. That also makes error codes 33 to 36 reachable for the first time, which is most of what was missing from the coverage figure.

Valid input is untouched, including the day-of-`00` reading that turns a date into the last day of its month.

## The sliding window

The half of the year window that reads a year as belonging to the century *ahead* needs a two digit year at least fifty behind the current one. That cannot be written in two digits before 2050, so no fixed date would ever have exercised it. It is reached by moving the clock with `jasmine.clock().mockDate()` instead.

The same specs now pin both edges deterministically rather than depending on what year it happens to be, while the "as the clock stands today" block still checks the window really does move.

## The two that stay uncovered

Two guards cannot be reached by construction:

- the `default` arm of the element type switch — every construction in the file passes `S`, `N` or `D`;
- the `default` arm of the message switch — every code the parser throws has an arm of its own.

Both are worth keeping. They are held out of the figure with `/* c8 ignore */` and a comment saying why, rather than deleted to flatter the number.

## Thresholds

Set at 100. Verified they bite rather than decorate: removing the new spec file drops the run to 99.36% statements and 98.04% branches, and the build fails.

313 specs, 0 failures.
