### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Notable changes to `gs1-barcode-parser-mod`. The format follows
 
 Releases before 1.0.3 predate this file and are not reconstructed here.
 
-## Unreleased
+## 1.1.0 - 2026-08-13
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gs1-barcode-parser-mod",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "The barcode parser is a library for handling the contents of GS1 barcodes.",
   "main": "src/BarcodeParser.js",
   "files": [


### PR DESCRIPTION
Stamps the changelog section and moves the version to 1.1.0. Merging this publishes — the workflow skips whenever the version is already on the registry, which is why nothing has released since 1.0.8.

Two line diff; the content is already on `master`. See [CHANGELOG.md](CHANGELOG.md) for what goes out.

Checked on this branch: 358 specs, 100% coverage, and the publish guard confirms 1.1.0 is not yet on the registry.

Worth tagging `v1.1.0` afterwards — only `v1.0.7` is tagged today.
