### PR TITLE
Carry the date of a date element as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Releases before 1.0.3 predate this file and are not reconstructed here.
   with the two digit one puts the date in the wrong century and leaves the surplus digits
   behind to be parsed as another identifier, so the barcode comes back with a spurious
   extra element instead of an error. ([#9])
+- Date elements carry their date as text in a new `isoDate`, e.g. `"2025-06-30"`, or
+  `"1985-06-30T14:35"` where the element holds a time. A date without a time of day cannot be
+  carried unambiguously in a Javascript `Date` — reading one back means choosing between the
+  local getters and the UTC ones, and either choice shifts the day for somebody. The text says
+  the day the barcode says, wherever the reader sits. ([#15])
 - The human readable form of an element string is accepted:
   `(01)04012345678901(17)261230(10)ABC123`. It is rewritten into the separated form and
   parsed by the same identifiers as a scanned code, so both give the same result. Without a
@@ -141,3 +146,4 @@ rest of the tags exist.
 [#10]: https://github.com/MaximBelov/BarcodeParser/pull/10
 [#11]: https://github.com/MaximBelov/BarcodeParser/pull/11
 [#13]: https://github.com/MaximBelov/BarcodeParser/pull/13
+[#15]: https://github.com/MaximBelov/BarcodeParser/pull/15

--- a/README.md
+++ b/README.md
@@ -133,11 +133,19 @@ try {
 The function returns an object containing two elements:
 
 * `codeName`: a barcode type identifier (a simple string denoting the type of barcode) and
-* `parsedCodeItems`: an array of objects, each with four attributes:
+* `parsedCodeItems`: an array of objects, each with these attributes:
  * `ai`: the application identifier
  * `title`: the title of the element, i.e. a short description
  * `data`: the contents, either a string, a number or a date
  * `unit`: the unit of measurement, a country code, a currency; denoted in ISO codes.
+ * `raw`: the untouched substring the contents were read from
+ * `isoDate`: for a date element, its date as text, e.g. `"2025-06-30"`; empty on every other kind of element
+
+A date without a time of day cannot be carried unambiguously in a Javascript `Date`: reading one
+back means knowing whether to use the local getters or the UTC ones, and either choice shifts the
+day for somebody. `parseBarcode("]C117250630")` serialised with `toISOString()` from Auckland gives
+the 29th of June. That is what `isoDate` is for — it says the day the barcode says, wherever the
+reader sits. An element carrying a time of day puts that there too: `"1985-06-30T14:35"`.
 
 From the example above: `parseBarcode()` will return an object with "GS1-128" in its attribute `codeName`, the fourth element of `parsedCodeItems` is an object which has the attributes
 

--- a/spec/IsoDateSpec.js
+++ b/spec/IsoDateSpec.js
@@ -1,0 +1,95 @@
+/**
+ * A date without a time of day cannot be carried unambiguously in a Javascript
+ * Date. Whoever reads one has to know whether to use the local getters or the
+ * UTC ones, and either choice shifts the day for somebody: read
+ * `parseBarcode("]C117250630")` with toISOString() from Auckland and the answer
+ * is the 29th of June.
+ *
+ * So date elements carry their date as text as well, which says the day the
+ * barcode says, wherever the reader happens to be.
+ */
+const { parseBarcode } = require("../src/BarcodeParser");
+
+const fncChar = String.fromCharCode(29); // the ASCII "group separator"
+
+function firstElement(barcode) {
+    return parseBarcode(barcode).parsedCodeItems[0];
+}
+
+describe("The date an element was read as, in text", () => {
+    it("is given for an expiry date", () => {
+        expect(firstElement("]C117250630").isoDate).toBe("2025-06-30");
+    });
+
+    it("is given for every other kind of date element", () => {
+        expect(firstElement("]C111250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C112250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C113250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C115250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C116250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C14326250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C17006250630").isoDate).toBe("2025-06-30");
+        expect(firstElement("]C17007250630").isoDate).toBe("2025-06-30");
+    });
+
+    it("says the day a day of 00 was resolved to, not the digits as scanned", () => {
+        const element = firstElement("]C117250600");
+
+        expect(element.raw).toBe("250600");
+        expect(element.isoDate).toBe("2025-06-30");
+    });
+
+    it("carries the four digit year of a date of birth", () => {
+        expect(firstElement("]C1725019850630").isoDate).toBe("1985-06-30");
+    });
+
+    it("carries the time as well when the element holds one", () => {
+        expect(firstElement("]C17251198506301435").isoDate).toBe("1985-06-30T14:35");
+    });
+
+    it("pads a single digit month, day, hour and minute", () => {
+        expect(firstElement("]C117250101").isoDate).toBe("2025-01-01");
+        expect(firstElement("]C17251198501010905").isoDate).toBe("1985-01-01T09:05");
+    });
+
+    it("is empty on an element which holds no date", () => {
+        const result = parseBarcode(`]C10104012345678901${fncChar}10ABC123`);
+
+        expect(result.parsedCodeItems[0].isoDate).toBe("");
+        expect(result.parsedCodeItems[1].isoDate).toBe("");
+    });
+
+    it("is empty on a measure", () => {
+        expect(firstElement("]C13103000525").isoDate).toBe("");
+    });
+});
+
+describe("The date in text, read from a different timezone", () => {
+    const realTimezone = process.env.TZ;
+
+    afterEach(() => {
+        if (realTimezone === undefined) {
+            delete process.env.TZ;
+        } else {
+            process.env.TZ = realTimezone;
+        }
+    });
+
+    ["UTC", "America/New_York", "Pacific/Auckland", "Asia/Kolkata"].forEach((timezone) => {
+        it(`says the same day in ${timezone}`, () => {
+            process.env.TZ = timezone;
+
+            expect(firstElement("]C117250630").isoDate).toBe("2025-06-30");
+        });
+    });
+
+    it("says the day the Date itself does not, east of Greenwich", () => {
+        process.env.TZ = "Pacific/Auckland";
+
+        const element = firstElement("]C117250630");
+
+        // This is the whole point: serialising the Date loses a day here.
+        expect(element.data.toISOString().slice(0, 10)).toBe("2025-06-29");
+        expect(element.isoDate).toBe("2025-06-30");
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -84,6 +84,8 @@ const parseBarcode = (function () {
             }
             this.unit = ""; // some elements are accompaigned by an unit of
             // measurement or currency
+            this.isoDate = ""; // date elements also carry their date as text,
+            // empty on every other kind of element
         }
 
         /**
@@ -160,6 +162,32 @@ const parseBarcode = (function () {
                 }
 
                 return auxFloat;
+            }
+            /**
+             * Writes the date an element was read as into its isoDate, as text.
+             *
+             * A date without a time of day cannot be carried unambiguously in a
+             * Javascript Date: whoever reads it has to know whether to use the
+             * local getters or the UTC ones, and picking either shifts the day
+             * for somebody. The text is read off the local getters, which are
+             * the ones the date was built with, so it says the day the barcode
+             * says whatever timezone the reader sits in.
+             *
+             * @param {Date}    date     the date the element was read as
+             * @param {Boolean} withTime whether the element carried a time too
+             */
+            function setIsoDate(date, withTime) {
+                var text = String(date.getFullYear()).padStart(4, "0") + "-" +
+                        String(date.getMonth() + 1).padStart(2, "0") + "-" +
+                        String(date.getDate()).padStart(2, "0");
+
+                if (withTime) {
+                    text = text + "T" +
+                        String(date.getHours()).padStart(2, "0") + ":" +
+                        String(date.getMinutes()).padStart(2, "0");
+                }
+
+                elementToReturn.isoDate = text;
             }
             /**
              * Elements of fixed length are spliced out of the codestring by
@@ -271,6 +299,7 @@ const parseBarcode = (function () {
                 }
 
                 elementToReturn.data.setFullYear(yearAsNumber, monthAsNumber, dayAsNumber);
+                setIsoDate(elementToReturn.data, false);
                 codestringToReturn = codestring.slice(offSet + 6, codestringLength);
                 elementToReturn.raw = codestring.slice(offSet, offSet+6);
             }
@@ -339,6 +368,7 @@ const parseBarcode = (function () {
                     throw "35";
                 }
 
+                setIsoDate(elementToReturn.data, withTime);
                 codestringToReturn = codestring.slice(offSet + length, codestringLength);
                 elementToReturn.raw = digits;
             }


### PR DESCRIPTION
Closes the problem behind #2 without the trade-off that PR carries.

A date with no time of day cannot be carried unambiguously in a `Date`. Reading one back means choosing local getters or UTC ones, and either choice shifts the day for someone:

```js
process.env.TZ = "Pacific/Auckland";
parseBarcode("]C117250630").parsedCodeItems[0].data.toISOString();  // 2025-06-29 — wrong day
```

So date elements now also carry `isoDate`:

```js
parseBarcode("]C117250630").parsedCodeItems[0].isoDate            // "2025-06-30"
parseBarcode("]C17251198506301435").parsedCodeItems[0].isoDate     // "1985-06-30T14:35"
```

It is the resolved date, so a day of `00` reads as the last day of that month. Empty on elements that hold no date.

Nothing existing changes. #2 instead moves `data` itself to UTC, which fixes the ISO case and breaks the local-getter one — merged onto current `master` it fails 1 spec in CEST and 3 in New York, and leaves `parseDate` and `parseLongDate` disagreeing about midnight.

371 specs, 0 failures, run in UTC, Dublin and New York. Coverage still 100%.
