### PR TITLE
Refuse an identifier the parser cannot complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Notable changes to `gs1-barcode-parser-mod`. The format follows
 
 Releases before 1.0.3 predate this file and are not reconstructed here.
 
+## Unreleased
+
+### Added
+
+- Date elements carry their date as text in a new `isoDate`, e.g. `"2025-06-30"`, or
+  `"1985-06-30T14:35"` where the element holds a time. A date without a time of day cannot be
+  carried unambiguously in a Javascript `Date` — reading one back means choosing between the
+  local getters and the UTC ones, and either choice shifts the day for somebody. The text says
+  the day the barcode says, wherever the reader sits. ([#15])
+
+### Fixed
+
+- A barcode which stops part way through an application identifier is refused instead of
+  coming back as a successful parse holding an empty element. Several inner switches carry no
+  default arm, so 26 three digit prefixes — `]C1230`, `]C1430`, `]C1701` and the rest — matched
+  nothing, parsed nothing, and returned `""` where an element should have been. Some are a real
+  family with the last digit missing, others name nothing the standard defines. The guard sits
+  at the end of the identifier switch rather than in each arm, so an identifier added later
+  without a default cannot bring it back. ([#16])
+
 ## 1.1.0 - 2026-08-13
 
 ### Added
@@ -16,11 +36,6 @@ Releases before 1.0.3 predate this file and are not reconstructed here.
   with the two digit one puts the date in the wrong century and leaves the surplus digits
   behind to be parsed as another identifier, so the barcode comes back with a spurious
   extra element instead of an error. ([#9])
-- Date elements carry their date as text in a new `isoDate`, e.g. `"2025-06-30"`, or
-  `"1985-06-30T14:35"` where the element holds a time. A date without a time of day cannot be
-  carried unambiguously in a Javascript `Date` — reading one back means choosing between the
-  local getters and the UTC ones, and either choice shifts the day for somebody. The text says
-  the day the barcode says, wherever the reader sits. ([#15])
 - The human readable form of an element string is accepted:
   `(01)04012345678901(17)261230(10)ABC123`. It is rewritten into the separated form and
   parsed by the same identifiers as a scanned code, so both give the same result. Without a
@@ -147,3 +162,4 @@ rest of the tags exist.
 [#11]: https://github.com/MaximBelov/BarcodeParser/pull/11
 [#13]: https://github.com/MaximBelov/BarcodeParser/pull/13
 [#15]: https://github.com/MaximBelov/BarcodeParser/pull/15
+[#16]: https://github.com/MaximBelov/BarcodeParser/pull/16

--- a/spec/IncompleteIdentifiersSpec.js
+++ b/spec/IncompleteIdentifiersSpec.js
@@ -1,0 +1,73 @@
+/**
+ * A barcode can stop part way through an application identifier — a half read
+ * scan, or a code cut short. Several of the inner switches carry no default arm,
+ * so the digit they were about to read simply is not there, nothing matches,
+ * nothing parses, and the element the parser was building is left as the empty
+ * string it started as.
+ *
+ * That used to be pushed onto the answer: parseBarcode("]C1430") came back as a
+ * successful parse whose one element was "". These are the 26 three digit
+ * prefixes it happened for. Some are a real family with the last digit missing,
+ * 430x being one; others name nothing the standard defines, 230x being one.
+ */
+const { parseBarcode } = require("../src/BarcodeParser");
+
+const incompletePrefixes = [
+    "230", "231", "232", "233", "234", "236", "237", "238", "239",
+    "430", "431", "432", "433",
+    "701", "702", "704",
+    "720", "721", "722", "724", "725", "726", "727", "728", "729",
+    "803"
+];
+
+describe("A barcode which stops part way through an identifier", () => {
+    incompletePrefixes.forEach((prefix) => {
+        it(`refuses ]C1${prefix}`, () => {
+            expect(() => parseBarcode(`]C1${prefix}`)).toThrow("unrecognised AI");
+        });
+    });
+
+    it("never returns an element which is not a parsed element", () => {
+        incompletePrefixes.forEach((prefix) => {
+            let items = null;
+
+            try {
+                items = parseBarcode(`]C1${prefix}`).parsedCodeItems;
+            } catch (refused) {
+                items = null;
+            }
+
+            expect(items).toBeNull();
+        });
+    });
+
+    it("refuses the same prefix without a symbology identifier", () => {
+        expect(() => parseBarcode("430")).toThrow("unrecognised AI");
+    });
+
+    it("refuses it in the parenthesised form too", () => {
+        expect(() => parseBarcode("(430)")).toThrow("unrecognised AI");
+    });
+});
+
+describe("The identifiers which do exist, given their missing digit", () => {
+    it("parse as they always did", () => {
+        expect(parseBarcode("]C14300ABC").parsedCodeItems[0].ai).toBe("4300");
+        expect(parseBarcode("]C14309" + "1".repeat(20)).parsedCodeItems[0].ai).toBe("4309");
+        expect(parseBarcode("]C17010ABC").parsedCodeItems[0].ai).toBe("7010");
+        expect(parseBarcode("]C17011250630").parsedCodeItems[0].ai).toBe("7011");
+    });
+
+    it("are still refused where no such identifier exists at all", () => {
+        // 235 is the only 23x the standard defines, so no fourth digit helps.
+        expect(() => parseBarcode("]C12300ABC")).toThrow("unrecognised AI");
+        expect(parseBarcode("]C1235ABC").parsedCodeItems[0].ai).toBe("235");
+    });
+
+    it("still parse when the barcode carries more elements after them", () => {
+        const fncChar = String.fromCharCode(29); // the ASCII "group separator"
+        const result = parseBarcode(`]C14300ABC${fncChar}10BATCH42`);
+
+        expect(result.parsedCodeItems.map((item) => item.ai)).toEqual(["4300", "10"]);
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -1727,6 +1727,21 @@ const parseBarcode = (function () {
              * functions) and the (cleaned) rest of codestring.
              */
 
+            /**
+             * Several of the inner switches carry no default arm, so nothing
+             * matches and nothing parses when the digit one of them is about to
+             * read is missing, or names something the parser does not know.
+             * elementToReturn is then left the empty string it started as, and
+             * that used to be pushed onto the answer: the caller got a
+             * successful parse holding "" rather than an error.
+             *
+             * Guarding here rather than in each of those switches means an AI
+             * added later without a default cannot bring the fault back.
+             */
+            if (elementToReturn === "") {
+                throw "39";
+            }
+
             return ({
                 element: elementToReturn,
                 codestring: cleanCodestring(codestringToReturn)
@@ -2012,6 +2027,8 @@ const parseBarcode = (function () {
                     throw "invalid number";
                 case "37":
                     throw "truncated fixed length element";
+                case "39":
+                    throw "unrecognised AI";
                 /* c8 ignore start -- every code the parser throws has an arm
                    above, so this one cannot be reached. It stays as the guard
                    it is, and is kept out of the coverage figure rather than


### PR DESCRIPTION
`parseBarcode("]C1430")` returned a **successful** parse whose one element was `""`:

```js
parseBarcode("]C1430").parsedCodeItems   // [""]  — no error
```

Several inner switches carry no default arm, so when the digit they are about to read is missing — or names something the parser does not know — nothing matches, nothing parses, and the element being built is left the empty string it started as. It then gets pushed onto the answer.

26 three digit prefixes did this: `230`-`234`, `236`-`239`, `430`-`433`, `701`, `702`, `704`, `720`-`722`, `724`-`729`, `803`. Some are a real family with the last digit missing (`430x`); others name nothing the standard defines (`230x`, where `235` is the only one there is).

Now refused with `unrecognised AI`. The guard sits at the end of the identifier switch rather than in each arm, so an identifier added later without a default cannot bring it back.

403 specs, 0 failures in UTC, Dublin and New York. Coverage still 100%.

## One correction to the changelog

The `isoDate` entry from #15 was sitting under `## 1.1.0`, but 1.1.0 was published before #15 merged — the released package does not contain it. Moved to a fresh unreleased section, along with this fix.
