### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Notable changes to `gs1-barcode-parser-mod`. The format follows
 
 Releases before 1.0.3 predate this file and are not reconstructed here.
 
-## Unreleased
+## 1.2.0 - 2026-08-13
 
 ### Added
 
@@ -18,6 +18,10 @@ Releases before 1.0.3 predate this file and are not reconstructed here.
 
 ### Fixed
 
+- README figures corrected. It claimed 205 identifiers against upstream's 134; counted the same
+  way for both, the parser accepts 226 and upstream 143. It also documented an element attribute
+  `title`, where the property is `dataTitle`, and sent readers to a `scripts` folder that no
+  longer exists. ([#17])
 - A barcode which stops part way through an application identifier is refused instead of
   coming back as a successful parse holding an empty element. Several inner switches carry no
   default arm, so 26 three digit prefixes — `]C1230`, `]C1430`, `]C1701` and the rest — matched
@@ -163,3 +167,4 @@ rest of the tags exist.
 [#13]: https://github.com/MaximBelov/BarcodeParser/pull/13
 [#15]: https://github.com/MaximBelov/BarcodeParser/pull/15
 [#16]: https://github.com/MaximBelov/BarcodeParser/pull/16
+[#17]: https://github.com/MaximBelov/BarcodeParser/pull/17

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Forked from [upstream](https://github.com/PeterBrockfeld/BarcodeParser), whose `
 Published as [`gs1-barcode-parser-mod`](https://www.npmjs.com/package/gs1-barcode-parser-mod).
 
 Changes from upstream:
-- Covers 205 application identifiers against upstream's 134; the 41x, 43x, 70xx, 71x, 72xx, 725x, 80xx and 82xx families were added since the fork point.
+- Covers 226 application identifiers against upstream's 143; the 41x, 43x, 70xx, 71x, 72xx, 725x, 80xx and 82xx families were added since the fork point.
 - Reads the person related identifiers used in healthcare (7250-7259), whose dates carry a four digit year rather than the two digit year of the older date elements.
 - Resolves a two digit year with the sliding window from section 7.1.2 of the GS1 General Specifications, relative to the current year, instead of upstream's fixed "51-99 belongs to the 20th century" rule.
 - Exports `parseBarcode` as a CommonJS module rather than leaving it a browser global, so it can be `require`d.
@@ -135,7 +135,7 @@ The function returns an object containing two elements:
 * `codeName`: a barcode type identifier (a simple string denoting the type of barcode) and
 * `parsedCodeItems`: an array of objects, each with these attributes:
  * `ai`: the application identifier
- * `title`: the title of the element, i.e. a short description
+ * `dataTitle`: the title of the element, i.e. a short description
  * `data`: the contents, either a string, a number or a date
  * `unit`: the unit of measurement, a country code, a currency; denoted in ISO codes.
  * `raw`: the untouched substring the contents were read from
@@ -150,11 +150,11 @@ reader sits. An element carrying a time of day puts that there too: `"1985-06-30
 From the example above: `parseBarcode()` will return an object with "GS1-128" in its attribute `codeName`, the fourth element of `parsedCodeItems` is an object which has the attributes
 
 * "3932" as `ai`,
-* "PRICE" as `title`,
+* "PRICE" as `dataTitle`,
 * "47.11" as `data` (a floating point number) and
 * "978" as `unit` (the ISO code for €)
 
-Some remarks about how the function works can be found in `README_scripts.md` within the `scripts` folder.
+Some remarks about how the function works can be found in `README_scripts.md` within the `src` folder.
 
 ### Limitations
 
@@ -229,8 +229,10 @@ npm test          # lint, then the spec suite
 npm run build     # minified build into dist/
 ```
 
-`spec/ApplicationIdentifiersSpec.js` parses every application identifier the library
-claims to support and checks each one comes back under its own AI. The parser is a
+`spec/ApplicationIdentifiersSpec.js` holds a table of 208 application identifiers and
+checks each one comes back under its own AI. Identifiers whose last digit only says how
+many decimals follow, `310x` and its like, are represented by one entry rather than all
+ten, which is why the table is shorter than the 226 the parser accepts. The parser is a
 single large nested `switch`, where a missing `break` makes an identifier throw, return
 `undefined`, or silently parse as its neighbour — so an identifier added without being
 wired up correctly fails the suite rather than shipping.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gs1-barcode-parser-mod",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The barcode parser is a library for handling the contents of GS1 barcodes.",
   "main": "src/BarcodeParser.js",
   "files": [


### PR DESCRIPTION
Releases `isoDate` (#15) and the unrecognised-AI guard (#16), which both landed after 1.1.0 was published, and corrects the README figures found while auditing the day's work.

The README was wrong on three counts:

- **226, not 205** identifiers, against **upstream's 143, not 134** — the old numbers came from an extraction that missed identifiers built by concatenation, and the two sides were counted by different rules.
- `title` is not a property. It is `dataTitle`, in the attribute list and in the worked example.
- `README_scripts.md` is in `src`, not in a `scripts` folder, which has not existed since the fork.

Also softened the claim that the AI table holds every supported identifier: it holds 208 for 226, because `310x` and its like are represented by one entry rather than all ten. The README now says that rather than overstating it.

403 specs, coverage 100%.
