### PR TITLE
Refuse 703 and 723 without their fourth digit (1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Notable changes to `gs1-barcode-parser-mod`. The format follows
 
 Releases before 1.0.3 predate this file and are not reconstructed here.
 
+## 1.2.1 - 2026-08-13
+
+### Fixed
+
+- `703` and `723` build their identifier by putting the fourth digit onto a stem rather than by
+  matching it, so a barcode stopping before that digit had no switch arm to fall through and came
+  back as a successful parse whose `ai` was `"703"` or `"723"` — neither of which the standard
+  defines — with a title trailing off after the `#`. Both are refused now. ([#18])
+
 ## 1.2.0 - 2026-08-13
 
 ### Added
@@ -168,3 +177,4 @@ rest of the tags exist.
 [#15]: https://github.com/MaximBelov/BarcodeParser/pull/15
 [#16]: https://github.com/MaximBelov/BarcodeParser/pull/16
 [#17]: https://github.com/MaximBelov/BarcodeParser/pull/17
+[#18]: https://github.com/MaximBelov/BarcodeParser/pull/18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gs1-barcode-parser-mod",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The barcode parser is a library for handling the contents of GS1 barcodes.",
   "main": "src/BarcodeParser.js",
   "files": [

--- a/spec/IncompleteIdentifiersSpec.js
+++ b/spec/IncompleteIdentifiersSpec.js
@@ -71,3 +71,38 @@ describe("The identifiers which do exist, given their missing digit", () => {
         expect(result.parsedCodeItems.map((item) => item.ai)).toEqual(["4300", "10"]);
     });
 });
+
+/**
+ * Two identifiers are built by putting the fourth digit onto a stem rather than
+ * by matching it, so there is no switch arm to fall through: a barcode stopping
+ * before that digit came back with an ai of "703" or "723", neither of which the
+ * standard defines, and a title trailing off after the "#".
+ */
+describe("An identifier whose fourth digit makes up its number", () => {
+    it("refuses a processor number with no fourth digit", () => {
+        expect(() => parseBarcode("]C1703")).toThrow("unrecognised AI");
+    });
+
+    it("refuses a certification reference with no fourth digit", () => {
+        expect(() => parseBarcode("]C1723")).toThrow("unrecognised AI");
+    });
+
+    it("reads them once the fourth digit is there", () => {
+        expect(parseBarcode("]C17030056ABC").parsedCodeItems[0]).toEqual(jasmine.objectContaining({
+            ai: "7030",
+            dataTitle: "PROCESSOR # 0",
+            data: "ABC",
+            unit: "056"
+        }));
+        expect(parseBarcode("]C17239ABC123").parsedCodeItems[0]).toEqual(jasmine.objectContaining({
+            ai: "7239",
+            dataTitle: "CERT # 9",
+            data: "ABC123"
+        }));
+    });
+
+    it("leaves a real three digit identifier alone", () => {
+        // 421 is three digits by definition, not a stem waiting for a fourth.
+        expect(parseBarcode("]C1421056ABC").parsedCodeItems[0].ai).toBe("421");
+    });
+});

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -164,6 +164,22 @@ const parseBarcode = (function () {
                 return auxFloat;
             }
             /**
+             * Two identifiers are built by putting the fourth digit onto a stem
+             * rather than by matching it: "703" and "723". A barcode which stops
+             * before that digit therefore yielded an element whose ai was the
+             * three digit stem, which is not an identifier the standard defines,
+             * and whose title trailed off after the "#".
+             *
+             * The switches which match their fourth digit have a default arm to
+             * catch this; these two have nothing to match, so they ask here.
+             */
+            function checkFourthNumber() {
+                if (fourthNumber === "") {
+                    throw "39";
+                }
+            }
+
+            /**
              * Writes the date an element was read as into its isoDate, as text.
              *
              * A date without a time of day cannot be carried unambiguously in a
@@ -1371,6 +1387,7 @@ const parseBarcode = (function () {
 
                         // Title and stem for parsing are build from 4th number:
 
+                        checkFourthNumber();
                         parseVariableLengthWithISOChars("703" + fourthNumber, "PROCESSOR # " + fourthNumber);
                         break;
                     case "4":
@@ -1432,6 +1449,7 @@ const parseBarcode = (function () {
                     // 0, 1 and 2 are unused
                     case "3":
                         // Certification reference
+                        checkFourthNumber();
                         parseVariableLength("723" + fourthNumber, "CERT # " + fourthNumber);
                         break;
                     case "4":


### PR DESCRIPTION
`703` and `723` build their identifier by putting the fourth digit onto a stem instead of matching it, so unlike every other family there is no switch arm to fall through:

```
]C1703  ->  { ai: "703", dataTitle: "PROCESSOR # ", data: "" }   — a successful parse
]C1723  ->  { ai: "723", dataTitle: "CERT # ",      data: "" }
```

Neither `703` nor `723` is an identifier the standard defines, and the title trails off after the `#`. Both are refused now with `unrecognised AI`.

The guard added in 1.2.0 misses this: it fires when nothing was parsed at all, and here an element *is* built — just a nonsense one.

`421`, `423` and `427` are three digits by definition rather than stems waiting for a fourth, so they are untouched. `7030`-`7039` and `7230`-`7239` still parse.

Releases as 1.2.1. 407 specs, coverage still 100%.
